### PR TITLE
Add team information and wallet addresses to registry

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -146,3 +146,15 @@
     evm: "0x0000000000000000000000020d67a3C4174e27A3"
     flow: "0xaec929f96ea89ae4"
 -
+-
+  name: Magix
+  github:
+    - Borngreat Ikwutah (https://github.com/borngreat-ikwutah)
+  repos:
+    - https://github.com/borngreat-ikwutah/magix
+  wallets:
+    # Your team's wallets to accept Flow Rewards
+    evm: "0x9597d6346946D55C5D4004269c79945eB8BAC4b7"
+    flow: "0xc0ad9a569b0fc413"
+   x:
+    - @borngreatik23


### PR DESCRIPTION
This pull request adds a new team entry for "Magix" to the `registry.yaml` file, including relevant metadata such as GitHub information, repository URL, and wallet addresses.

**New team registration:**

* Added a new team named `Magix` with associated GitHub user (`Borngreat Ikwutah`), repository link (`https://github.com/borngreat-ikwutah/magix`), EVM and Flow wallet addresses, and an `x` handle (`@borngreatik23`).
* Below is a description of my entry to Flow ReWTF program