### PR TITLE
Add team information and wallet addresses to registry

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -145,4 +145,14 @@
   wallets:
     evm: "0x0000000000000000000000020d67a3C4174e27A3"
     flow: "0xaec929f96ea89ae4"
--
+--
+  name: Magix
+  github:
+    - borngreat-ikwutah
+  repos:
+    - https://github.com/borngreat-ikwutah/magix
+  wallets: # Optional, Your wallets to accept Flow Rewards
+    evm: "0x9597d6346946D55C5D4004269c79945eB8BAC4b7"
+    flow: "0xc0ad9a569b0fc413"
+  x: # Optional, Your team's social handles
+    - borngreatik23


### PR DESCRIPTION
This pull request adds a new team entry to the `registry.yaml` file, including relevant GitHub and social information, as well as wallet addresses for rewards.

Team addition:

* Added a new team named `Magix` with associated GitHub user (`borngreat-ikwutah`), repository link, EVM and Flow wallet addresses, and X (Twitter) social handle.