### PR TITLE
Add Curio Storage to ReWTF registry

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -1,11 +1,13 @@
 # ------ Start - Template -----
 # Copy the following structure as your registration information!
 -
-  name: Team Name(Displayed in Leaderboard)
+  name: Curio Storage
   github:
     # Your team members' Github usernames, for tracking your PR status to onflow
-    - username1
-    - username2
+    - LexLuthr
+    - magik6k
+    - snadrus
+    - Reiers
   repos:
     # Your repositories, all commits to these repos will be tracked. Only repos that meet
     # either of the two following requirements can be included and accepted:
@@ -13,13 +15,14 @@
     #    if there are any contracts, list the contract addresses deployed on Flow.
     # 2. With Flow components: Cadence Language, or with `@onflow/fcl` or `@onflow/kit`(in package.json), or using
     #    go sdk(url in go.mod), or with Flow public EVM endpoints set(in Solidity configure files).
-    - https://github.com/your/repo_1
-    - https://github.com/your/repo_2
+    - https://github.com/filecoin-project/curio
+    - https://github.com/filecoin-project/apt
+    - https://github.com/Reiers/The-CalibrationNet-Stability-Project
   wallets: # Optional, Your wallets to accept Flow Rewards
-    evm: "0x0000000000000000000000000000000000000000"
-    flow: "0x0000000000000001"
+    evm: "0x876EE609A0556559F28a8159972cE6222A2e98aE"
+    flow: "0xb8378d0de0932d58"
   x: # Optional, Your team's social handles
-    - your_x_handle
+    - https://x.com/curiostorage
 # ------ End - Template -----
 # >>>>>>> Developers' registry <<<<<<<<
 -


### PR DESCRIPTION
Team: Curio Storage

Repos:
- https://github.com/filecoin-project/curio

Wallets:
- EVM: 0x876EE609A0556559F28a8159972cE6222A2e98aE
- Flow: 0xb8378d0de0932d58

Flow eligibility:
We’re a Filecoin team, and we also use Flow EVM (Chain ID 747) via MetaMask. The repository is:
https://github.com/filecoin-project/curio