### PR TITLE
Add Curio Storage to ReWTF registry

### DIFF
--- a/registry.yaml
+++ b/registry.yaml
@@ -23,6 +23,20 @@
 # ------ End - Template -----
 # >>>>>>> Developers' registry <<<<<<<<
 -
+  name: Curio Storage
+  github:
+    - LexLuthr
+    - magik6k
+    - snadrus
+    - Reiers
+  repos:
+    - https://github.com/filecoin-project/curio
+  wallets:
+    evm: "0x876EE609A0556559F28a8159972cE6222A2e98aE"
+    flow: "0xb8378d0de0932d58"
+  x:
+    - curiostorage
+-
   name: Fixes Lab
   github:
     - btspoony

--- a/registry.yaml
+++ b/registry.yaml
@@ -23,20 +23,6 @@
 # ------ End - Template -----
 # >>>>>>> Developers' registry <<<<<<<<
 -
-  name: Curio Storage
-  github:
-    - LexLuthr
-    - magik6k
-    - snadrus
-    - Reiers
-  repos:
-    - https://github.com/filecoin-project/curio
-  wallets:
-    evm: "0x876EE609A0556559F28a8159972cE6222A2e98aE"
-    flow: "0xb8378d0de0932d58"
-  x:
-    - curiostorage
--
   name: Fixes Lab
   github:
     - btspoony
@@ -160,3 +146,16 @@
     evm: "0x0000000000000000000000020d67a3C4174e27A3"
     flow: "0xaec929f96ea89ae4"
 -
+  name: Curio Storage
+  github:
+    - LexLuthr
+    - magik6k
+    - snadrus
+    - Reiers
+  repos:
+    - https://github.com/filecoin-project/curio
+  wallets:
+    evm: "0x876EE609A0556559F28a8159972cE6222A2e98aE"
+    flow: "0xb8378d0de0932d58"
+  x:
+    - curiostorage


### PR DESCRIPTION
Team: Curio Storage

Repos:
- https://github.com/filecoin-project/curio

Wallets:
- EVM: 0x876EE609A0556559F28a8159972cE6222A2e98aE
- Flow: 0xb8378d0de0932d58

Flow eligibility:
Curio is a Filecoin Storage Provider implementation, and we also integrate with the Flow ecosystem via Flow EVM (Chain ID 747). 
The repository README includes a Flow EVM Integration section: 
https://github.com/filecoin-project/curio#flow-evm-integration